### PR TITLE
Fixed compatibility with CL-SAT

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -37,7 +37,7 @@
                        (collect token))
            ((list* _ assignments)
             (values
-             (iter (for v in (sat-instance-variables *instance*))
+             (iter (for v in-vector (sat-instance-variables *instance*))
                    (for a in assignments)
                    (when (plusp a) (collect v)))
              t t))))


### PR DESCRIPTION
This is related to https://github.com/guicho271828/cl-sat/pull/4

Basically I fixed the accessing of `sat-instance-variables`: it's now a vector.

Tested on SBCL 1.5.2 (Mac OS X 10.11)
