### PR TITLE
Allow minisat to be installed automatically on Arch Linux

### DIFF
--- a/cl-sat.minisat.asd
+++ b/cl-sat.minisat.asd
@@ -31,6 +31,7 @@
                              :apt "minisat"
                              :dnf "minisat2"
                              :yum "minisat2"
+                             :pacman "minisat"
                              :brew "minisat"
                              :macports "minisat"
                              :env-alist `(("PATH" . ,(format nil "~a:~a"


### PR DESCRIPTION
This adds the package name for pacman.

https://github.com/guicho271828/trivial-package-manager/pull/2 is also needed to make it work.